### PR TITLE
Поддержка компонента cityFields

### DIFF
--- a/core/components/seofilter/elements/plugins/plugin.seofilter.php
+++ b/core/components/seofilter/elements/plugins/plugin.seofilter.php
@@ -203,6 +203,14 @@ switch ($modx->event->name) {
             if (!($SeoFilter instanceof SeoFilter)) {
                 break;
             }
+            
+            if (isset($_COOKIE['cfCity']) && intval($_COOKIE['cfCity']) > 0 && $modx->context->getOption('cityfields_active', false) && $modx->context->getOption('cityfields_cityinsubfolder', false) && intval($_COOKIE['cfCity']) != $modx->context->getOption('cityfields_default_city', 1)) {
+                $city = $modx->getObject('cfCity', intval($_COOKIE['cfCity']));
+                if ($city) {
+                    $city_key = strpos($city->get('key'), '/') !== false ? explode('/', $city->get('key'))[1] : $city->get('key');
+                    $_REQUEST[$alias] = str_replace($city_key.'/', '', $_REQUEST[$alias]);
+                }
+            }
 
             $SeoFilter->processUrl(trim($_REQUEST[$alias]));
         }

--- a/core/components/seofilter/model/seofilter/seofilter.class.php
+++ b/core/components/seofilter/model/seofilter/seofilter.class.php
@@ -82,8 +82,8 @@ class SeoFilter
                 }
                 $page_url = $this->clearSuffixes($page_url);
 
-                if (isset($_COOKIE['cfCity']) && $_COOKIE['cfCity'] > 0 && $this->modx->context->getOption('cityfields_active', false) && $this->modx->context->getOption('cityfields_cityinsubfolder', false) && $_COOKIE['cfCity'] != $this->modx->context->getOption('cityfields_default_city', 1)) {
-                    $city = $this->modx->getObject('cfCity', $_COOKIE['cfCity']);
+                if (isset($_COOKIE['cfCity']) && intval($_COOKIE['cfCity']) > 0 && $this->modx->context->getOption('cityfields_active', false) && $this->modx->context->getOption('cityfields_cityinsubfolder', false) && intval($_COOKIE['cfCity']) != $this->modx->context->getOption('cityfields_default_city', 1)) {
+                    $city = $this->modx->getObject('cfCity', intval($_COOKIE['cfCity']));
                     if ($city) {
                         $city_key = strpos($city->get('key'), '/') !== false ? explode('/', $city->get('key'))[1] : $city->get('key');
                         $page_url = str_replace(MODX_HTTP_HOST, MODX_HTTP_HOST.'/'.$city_key, $page_url);

--- a/core/components/seofilter/model/seofilter/seofilter.class.php
+++ b/core/components/seofilter/model/seofilter/seofilter.class.php
@@ -82,6 +82,14 @@ class SeoFilter
                 }
                 $page_url = $this->clearSuffixes($page_url);
 
+                if (isset($_COOKIE['cfCity']) && $_COOKIE['cfCity'] > 0 && $this->modx->context->getOption('cityfields_active', false) && $this->modx->context->getOption('cityfields_cityinsubfolder', false) && $_COOKIE['cfCity'] != $this->modx->context->getOption('cityfields_default_city', 1)) {
+                    $city = $this->modx->getObject('cfCity', $_COOKIE['cfCity']);
+                    if ($city) {
+                        $city_key = strpos($city->get('key'), '/') !== false ? explode('/', $city->get('key'))[1] : $city->get('key');
+                        $page_url = str_replace(MODX_HTTP_HOST, MODX_HTTP_HOST.'/'.$city_key, $page_url);
+                    }
+                }
+                
                 $this->config['url'] = $page_url;
 
                 $q = $this->modx->newQuery('sfFieldIds');


### PR DESCRIPTION
Добавлен код для поддержки виртуальных подкаталогов, создаваемых компонентом cityFields, по которым определяется текущий город, выбранный пользователем